### PR TITLE
Grouping performance improvements

### DIFF
--- a/src/PopupApp.tsx
+++ b/src/PopupApp.tsx
@@ -1,6 +1,6 @@
 import "./globals.css";
 import Button from "./components/Button";
-import { executeGrouping, unGroupAllTabs } from "./helpers/extensionHelpers";
+import { executeGrouping, ungroupAllTabs } from "./helpers/extensionHelpers";
 import RulesForm from "./components/RulesForm";
 import OptionsForm from "./components/OptionsForm";
 import useRulesRepository from "./hooks/useRulesRepository";
@@ -13,7 +13,7 @@ const PopupApp = () => {
     <div className="popup-app">
       <main className="main-actions">
         <Button onClick={executeGrouping}>Group</Button>
-        <Button onClick={unGroupAllTabs}>Un-Group</Button>
+        <Button onClick={ungroupAllTabs}>Un-Group</Button>
       </main>
       <section>
         <OptionsForm repo={optionsRepo} />

--- a/src/components/OptionsForm.tsx
+++ b/src/components/OptionsForm.tsx
@@ -38,14 +38,6 @@ const OptionsForm: FC<{
         />
 
         <OptionSwitch
-          optionName="preserveGroups"
-          label="Preserve Groups"
-          description="Ignores existing groups"
-          options={options}
-          setOption={setOption}
-        />
-
-        <OptionSwitch
           optionName="crossWindows"
           label="Cross Windows"
           description="Merge groups across windows."

--- a/src/helpers/RuleEngine.ts
+++ b/src/helpers/RuleEngine.ts
@@ -1,8 +1,9 @@
-import { GroupColor, Rule } from "../types";
+import { Rule } from "../types";
 import { EnrichedTab } from "./extensionHelpers";
 import { cleanText } from "./textHelpers";
 import { notNullish } from "./utilities";
 import Tab = chrome.tabs.Tab;
+import ColorEnum = chrome.tabGroups.ColorEnum;
 
 interface RuleEngineOptions {
   autoGroup: boolean;
@@ -12,7 +13,7 @@ export interface GroupSpec {
   title: string;
   tabs: Tab[];
   windowId: number;
-  color?: GroupColor;
+  color?: ColorEnum;
 }
 
 type RuleCheck = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Options {
   crossWindows: boolean;
   alphabetize: boolean;
   manualOrder: boolean;
-  preserveGroups: boolean;
+  preserveGroups: boolean /** @deprecated */;
 }
 
 export const defaultOptions: Options = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
-export const groupColors = [
+import ColorEnum = chrome.tabGroups.ColorEnum;
+
+export const groupColors: readonly ColorEnum[] = [
   "grey",
   "blue",
   "red",
@@ -7,14 +9,13 @@ export const groupColors = [
   "pink",
   "purple",
   "cyan",
-] as const;
-export type GroupColor = typeof groupColors[number];
+];
 
 export interface Rule {
   id: string;
   title: string;
   matches: string;
-  color: GroupColor;
+  color: ColorEnum;
 }
 
 export interface Options {


### PR DESCRIPTION
## Perf Notes
Testing in Brave Browser, 2 rules, auto-group, alphabetize
`106` tabs
`105` in proper group before execution

### Baseline
Sort: 150ms
Total: 551ms

### Patch
Sort: 131ms
Total: 142ms
